### PR TITLE
trac#22298: Consistent 'key not found' vs. 'key value invalid'

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/document/DocumentManager.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/DocumentManager.java
@@ -535,7 +535,7 @@ public class DocumentManager
     }
     catch (NodeNotFoundException e)
     {
-      pdMode = PersistentDataContainer.PERSISTENT_DATA_MODE_RDFREADLEGACY;
+      pdMode = PersistentDataContainer.PERSISTENT_DATA_MODE_TRANSITION;
       Logger.debug(L.m("Attribut %1 nicht gefunden. Verwende Voreinstellung '%2'.",
         PersistentDataContainer.PERSISTENT_DATA_MODE, pdMode));
     }


### PR DESCRIPTION
use the same PERSISTENT_DATA_MODE value when the key is not present
in wollmux config vs. when it is present, but its value is invalid

This band-aid prevents the crash described in trac#22298, as
defaulting to 'rdfReadLegacy' tries to modify the template. This is
fatal in combo with 6b85a5bfeb2c87e68f0f5dfaa76b23c5feab1bda