### PR TITLE
Cache für Vorlagen und Fragmente

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
 		<dependency>
 			<groupId>de.muenchen</groupId>
 			<artifactId>unohelper</artifactId>
-			<version>2.0.3-SNAPSHOT</version>
+			<version>2.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.muenchen</groupId>
 	<artifactId>wollmux</artifactId>
@@ -26,8 +28,8 @@
 				</excludes>
 			</resource>
 			<resource>
-			  <directory>src/main/resources</directory>
-        <filtering>true</filtering>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
 			</resource>
 			<resource>
 				<directory>izpack</directory>
@@ -121,7 +123,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.0</version>
 				<configuration>
 					<compilerVersion>1.8</compilerVersion>
 					<source>1.8</source>
@@ -260,7 +262,8 @@
 						<configuration>
 							<target>
 								<move file="dist/WollMux.zip" tofile="dist/WollMux.oxt" />
-								<move file="dist/WollMux-AOO.zip" tofile="dist/WollMux-AOO.oxt" />
+								<move file="dist/WollMux-AOO.zip"
+									tofile="dist/WollMux-AOO.oxt" />
 							</target>
 						</configuration>
 						<goals>
@@ -517,12 +520,17 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.1</version>
+			<version>4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
+			<version>3.8.1</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fifesoft</groupId>
@@ -538,6 +546,11 @@
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rstaui</artifactId>
 			<version>2.5.7</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>27.0-jre</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
 		<dependency>
 			<groupId>de.muenchen</groupId>
 			<artifactId>unohelper</artifactId>
-			<version>2.0.2</version>
+			<version>2.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/de/muenchen/allg/itd51/wollmux/document/ByteBufferInputStream.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/ByteBufferInputStream.java
@@ -2,13 +2,13 @@ package de.muenchen.allg.itd51.wollmux.document;
 
 import java.nio.ByteBuffer;
 
-import com.sun.star.io.BufferSizeExceededException;
 import com.sun.star.io.IOException;
-import com.sun.star.io.NotConnectedException;
 import com.sun.star.io.XInputStream;
 import com.sun.star.io.XSeekable;
-import com.sun.star.lang.IllegalArgumentException;
 
+/**
+ * Wrapper für ByteBuffer zur Benutzung mit UNO.
+ */
 public class ByteBufferInputStream implements XInputStream, XSeekable
 {
 
@@ -20,22 +20,19 @@ public class ByteBufferInputStream implements XInputStream, XSeekable
   }
 
   @Override
-  public int available()
-      throws NotConnectedException, com.sun.star.io.IOException
+  public int available() throws IOException
   {
     return buffer.remaining();
   }
 
   @Override
-  public void closeInput()
-      throws NotConnectedException, com.sun.star.io.IOException
+  public void closeInput() throws IOException
   {
     buffer = null;
   }
 
   @Override
-  public int readBytes(byte[][] data, int len) throws NotConnectedException,
-      BufferSizeExceededException, com.sun.star.io.IOException
+  public int readBytes(byte[][] data, int len) throws IOException
   {
     int n = Math.min(len, buffer.remaining());
     if (n > 0)
@@ -47,16 +44,13 @@ public class ByteBufferInputStream implements XInputStream, XSeekable
   }
 
   @Override
-  public int readSomeBytes(byte[][] data, int len)
-      throws NotConnectedException, BufferSizeExceededException,
-      com.sun.star.io.IOException
+  public int readSomeBytes(byte[][] data, int len) throws IOException
   {
     return readBytes(data, len);
   }
 
   @Override
-  public void skipBytes(int n) throws NotConnectedException,
-      BufferSizeExceededException, com.sun.star.io.IOException
+  public void skipBytes(int n) throws IOException
   {
     buffer.position(buffer.position() + n);
   }
@@ -74,7 +68,7 @@ public class ByteBufferInputStream implements XInputStream, XSeekable
   }
 
   @Override
-  public void seek(long pos) throws IllegalArgumentException, IOException
+  public void seek(long pos) throws IOException
   {
     buffer.position((int) pos);
   }

--- a/src/de/muenchen/allg/itd51/wollmux/document/ByteBufferInputStream.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/ByteBufferInputStream.java
@@ -1,0 +1,81 @@
+package de.muenchen.allg.itd51.wollmux.document;
+
+import java.nio.ByteBuffer;
+
+import com.sun.star.io.BufferSizeExceededException;
+import com.sun.star.io.IOException;
+import com.sun.star.io.NotConnectedException;
+import com.sun.star.io.XInputStream;
+import com.sun.star.io.XSeekable;
+import com.sun.star.lang.IllegalArgumentException;
+
+public class ByteBufferInputStream implements XInputStream, XSeekable
+{
+
+  private ByteBuffer buffer;
+
+  public ByteBufferInputStream(ByteBuffer buffer)
+  {
+    this.buffer = buffer;
+  }
+
+  @Override
+  public int available()
+      throws NotConnectedException, com.sun.star.io.IOException
+  {
+    return buffer.remaining();
+  }
+
+  @Override
+  public void closeInput()
+      throws NotConnectedException, com.sun.star.io.IOException
+  {
+    buffer = null;
+  }
+
+  @Override
+  public int readBytes(byte[][] data, int len) throws NotConnectedException,
+      BufferSizeExceededException, com.sun.star.io.IOException
+  {
+    int n = Math.min(len, buffer.remaining());
+    if (n > 0)
+    {
+      data[0] = new byte[n];
+      buffer.get(data[0], 0, n);
+    }
+    return n;
+  }
+
+  @Override
+  public int readSomeBytes(byte[][] data, int len)
+      throws NotConnectedException, BufferSizeExceededException,
+      com.sun.star.io.IOException
+  {
+    return readBytes(data, len);
+  }
+
+  @Override
+  public void skipBytes(int n) throws NotConnectedException,
+      BufferSizeExceededException, com.sun.star.io.IOException
+  {
+    buffer.position(buffer.position() + n);
+  }
+
+  @Override
+  public long getLength() throws IOException
+  {
+    return buffer.capacity();
+  }
+
+  @Override
+  public long getPosition() throws IOException
+  {
+    return buffer.position();
+  }
+
+  @Override
+  public void seek(long pos) throws IllegalArgumentException, IOException
+  {
+    buffer.position((int) pos);
+  }
+}

--- a/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -17,68 +19,122 @@ import com.sun.star.beans.PropertyState;
 import com.sun.star.beans.PropertyValue;
 import com.sun.star.io.XInputStream;
 import com.sun.star.lang.IllegalArgumentException;
-import com.sun.star.lib.uno.Proxy;
+import com.sun.star.lang.XComponent;
 import com.sun.star.uno.Exception;
 
 import de.muenchen.allg.afid.UNO;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
 
+/**
+ * Funktionen zum Laden und Einfügen von Dokumenten. Geladene Dokumente werden
+ * gecacht.
+ */
 public class DocumentLoader
 {
   private static final Logger LOGGER = LoggerFactory
-      .getLogger(DocumentLoader.class);
+    .getLogger(DocumentLoader.class);
 
+  private static DocumentLoader instance;
   private LoadingCache<URL, ByteBuffer> cache;
 
+  /**
+   * Zugriff auf den DocumentLoader als Singleton.
+   * 
+   * @return Singleton-Instanz des DocumentLoaders
+   */
   public static DocumentLoader getInstance()
   {
-    return new DocumentLoader();
+    if (instance == null)
+    {
+      instance = new DocumentLoader();
+    }
+    return instance;
   }
 
   private DocumentLoader()
   {
     cache = CacheBuilder.newBuilder()
-        .build(new CacheLoader<URL, ByteBuffer>()
+      .maximumSize(50)
+      .expireAfterAccess(8, TimeUnit.HOURS)
+      .build(new CacheLoader<URL, ByteBuffer>()
+      {
+        @Override
+        public ByteBuffer load(URL url) throws Exception
         {
-          @Override
-          public ByteBuffer load(URL url) throws Exception
-          {
-            return loadDocument(url);
-          }
-        });
+          return downloadDocument(url);
+        }
+      });
   }
 
-  private ByteBuffer loadDocument(URL url)
+  private ByteBuffer downloadDocument(URL url)
   {
     byte[] buf = null;
     try (InputStream in = url.openStream())
     {
       buf = IOUtils.toByteArray(in);
-    }
-    catch (IOException e)
+    } catch (IOException e)
     {
-      LOGGER.error(L.m(
-          "Die Vorlage mit der URL '%1' kann nicht geöffnet werden.", url), e);
+      LOGGER.error(
+        L.m("Die Vorlage mit der URL '%1' kann nicht geöffnet werden.", url),
+        e);
     }
 
     return ByteBuffer.wrap(buf);
   }
 
-  public void insertDocument(Proxy target, String path)
+  /**
+   * Lädt ein Dokument und fügt es an der Stelle von target ein. target muss den
+   * Service XDocumentInsertable unterstützen.
+   * 
+   * @param target
+   * @param path   URL des Dokuments
+   */
+  public void insertDocument(Object target, String path)
   {
     try
     {
-      ByteBuffer buf = cache.getUnchecked(new URL(path));
+      ByteBuffer buf = cache.get(new URL(path));
       XInputStream in = new ByteBufferInputStream(buf);
       UNO.XDocumentInsertable(target).insertDocumentFromURL(path,
-          new PropertyValue[] { new PropertyValue("InputStream", -1, in,
-              PropertyState.DIRECT_VALUE) });
-
-    }
-    catch (MalformedURLException | IllegalArgumentException
-        | com.sun.star.io.IOException e)
+        new PropertyValue[] {
+          new PropertyValue("InputStream", -1, in, PropertyState.DIRECT_VALUE),
+          new PropertyValue("FilterName", -1, "StarOffice XML (Writer)",
+            PropertyState.DIRECT_VALUE)
+        });
+    } catch (MalformedURLException | IllegalArgumentException
+      | com.sun.star.io.IOException | ExecutionException e)
     {
       LOGGER.error("", e);
     }
+  }
+  
+  /**
+   * Lädt ein Dokument und öffnet es.
+   * 
+   * @param path        URL des Dokuments
+   * @param asTemplate  behandelt das Dokument als Template
+   * @param allowMacros erlaubt die Ausführung von Makros
+   * 
+   * @return
+   */
+  public XComponent loadDocument(String path, boolean asTemplate,
+    boolean allowMacros)
+  {
+    try
+    {
+      ByteBuffer buf = cache.get(new URL(path));
+      XInputStream in = new ByteBufferInputStream(buf);
+      return UNO.loadComponentFromURL(path, asTemplate, allowMacros,
+          new PropertyValue("InputStream", -1, in, PropertyState.DIRECT_VALUE),
+          new PropertyValue("FilterName", -1, "StarOffice XML (Writer)",
+            PropertyState.DIRECT_VALUE)
+      );
+    } catch (MalformedURLException | IllegalArgumentException
+      | com.sun.star.io.IOException | ExecutionException e)
+    {
+      LOGGER.error("", e);
+    }
+
+    return null;
   }
 }

--- a/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
@@ -1,0 +1,84 @@
+package de.muenchen.allg.itd51.wollmux.document;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.sun.star.beans.PropertyState;
+import com.sun.star.beans.PropertyValue;
+import com.sun.star.io.XInputStream;
+import com.sun.star.lang.IllegalArgumentException;
+import com.sun.star.lib.uno.Proxy;
+import com.sun.star.uno.Exception;
+
+import de.muenchen.allg.afid.UNO;
+import de.muenchen.allg.itd51.wollmux.core.util.L;
+
+public class DocumentLoader
+{
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(DocumentLoader.class);
+
+  private LoadingCache<URL, ByteBuffer> cache;
+
+  public static DocumentLoader getInstance()
+  {
+    return new DocumentLoader();
+  }
+
+  private DocumentLoader()
+  {
+    cache = CacheBuilder.newBuilder()
+        .build(new CacheLoader<URL, ByteBuffer>()
+        {
+          @Override
+          public ByteBuffer load(URL url) throws Exception
+          {
+            return loadDocument(url);
+          }
+        });
+  }
+
+  private ByteBuffer loadDocument(URL url)
+  {
+    byte[] buf = null;
+    try (InputStream in = url.openStream())
+    {
+      buf = IOUtils.toByteArray(in);
+    }
+    catch (IOException e)
+    {
+      LOGGER.error(L.m(
+          "Die Vorlage mit der URL '%1' kann nicht geöffnet werden.", url), e);
+    }
+
+    return ByteBuffer.wrap(buf);
+  }
+
+  public void insertDocument(Proxy target, String path)
+  {
+    try
+    {
+      ByteBuffer buf = cache.getUnchecked(new URL(path));
+      XInputStream in = new ByteBufferInputStream(buf);
+      UNO.XDocumentInsertable(target).insertDocumentFromURL(path,
+          new PropertyValue[] { new PropertyValue("InputStream", -1, in,
+              PropertyState.DIRECT_VALUE) });
+
+    }
+    catch (MalformedURLException | IllegalArgumentException
+        | com.sun.star.io.IOException e)
+    {
+      LOGGER.error("", e);
+    }
+  }
+}

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
@@ -384,8 +384,6 @@ class DocumentExpander extends AbstractExecutor
     XTextCursor insCursor = cmd.getTextCursorWithinInsertMarks();
     if (UNO.XDocumentInsertable(insCursor) != null && urlStr != null)
     {
-      //      UNO.XDocumentInsertable(insCursor).insertDocumentFromURL(urlStr,
-      //        new PropertyValue[] {});
       DocumentLoader.getInstance().insertDocument(insCursor, urlStr);
     }
 

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
@@ -16,7 +16,6 @@ import com.sun.star.container.XEnumeration;
 import com.sun.star.container.XEnumerationAccess;
 import com.sun.star.io.IOException;
 import com.sun.star.lang.IllegalArgumentException;
-import com.sun.star.lib.uno.Proxy;
 import com.sun.star.style.XStyleFamiliesSupplier;
 import com.sun.star.style.XStyleLoader;
 import com.sun.star.text.XTextCursor;
@@ -387,7 +386,7 @@ class DocumentExpander extends AbstractExecutor
     {
       //      UNO.XDocumentInsertable(insCursor).insertDocumentFromURL(urlStr,
       //        new PropertyValue[] {});
-      DocumentLoader.getInstance().insertDocument((Proxy) insCursor, urlStr);
+      DocumentLoader.getInstance().insertDocument(insCursor, urlStr);
     }
 
     // Workaround: ParagraphStyleName für den letzten eingefügten Paragraphen

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
@@ -11,12 +11,12 @@ import java.util.Vector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.star.beans.PropertyValue;
 import com.sun.star.beans.XPropertySet;
 import com.sun.star.container.XEnumeration;
 import com.sun.star.container.XEnumerationAccess;
 import com.sun.star.io.IOException;
 import com.sun.star.lang.IllegalArgumentException;
+import com.sun.star.lib.uno.Proxy;
 import com.sun.star.style.XStyleFamiliesSupplier;
 import com.sun.star.style.XStyleLoader;
 import com.sun.star.text.XTextCursor;
@@ -42,6 +42,7 @@ import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.ConfigurationErrorException;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
+import de.muenchen.allg.itd51.wollmux.document.DocumentLoader;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
 
 /**
@@ -384,8 +385,9 @@ class DocumentExpander extends AbstractExecutor
     XTextCursor insCursor = cmd.getTextCursorWithinInsertMarks();
     if (UNO.XDocumentInsertable(insCursor) != null && urlStr != null)
     {
-      UNO.XDocumentInsertable(insCursor).insertDocumentFromURL(urlStr,
-        new PropertyValue[] {});
+      //      UNO.XDocumentInsertable(insCursor).insertDocumentFromURL(urlStr,
+      //        new PropertyValue[] {});
+      DocumentLoader.getInstance().insertDocument((Proxy) insCursor, urlStr);
     }
 
     // Workaround: ParagraphStyleName für den letzten eingefügten Paragraphen

--- a/src/de/muenchen/allg/itd51/wollmux/event/WollMuxEventHandler.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/WollMuxEventHandler.java
@@ -162,6 +162,7 @@ import de.muenchen.allg.itd51.wollmux.dialog.PersoenlicheAbsenderlisteVerwalten;
 import de.muenchen.allg.itd51.wollmux.dialog.formmodel.InvalidFormDescriptorException;
 import de.muenchen.allg.itd51.wollmux.dialog.formmodel.SingleDocumentFormModel;
 import de.muenchen.allg.itd51.wollmux.dialog.mailmerge.MailMergeNew;
+import de.muenchen.allg.itd51.wollmux.document.DocumentLoader;
 import de.muenchen.allg.itd51.wollmux.document.DocumentManager;
 import de.muenchen.allg.itd51.wollmux.document.DocumentManager.Info;
 import de.muenchen.allg.itd51.wollmux.document.DocumentManager.TextDocumentInfo;
@@ -1461,7 +1462,8 @@ public class WollMuxEventHandler
       TextDocumentController documentController = null;
       try
       {
-        XComponent doc = UNO.loadComponentFromURL(loadUrlStr, asTemplate, true);
+        XComponent doc = DocumentLoader.getInstance().loadDocument(loadUrlStr,
+          asTemplate, true);
 
         if (UNO.XTextDocument(doc) != null)
         {


### PR DESCRIPTION
Anders als beim Offline-Cache werden die Dokumente im Speicher gecacht. Das sollte speziell bei langsamen Internetverbindungen einen Verbesserung bringen, da Dokumente nur einmal geladen werden müssen. Der Traffic der vom WollMux erzeugt wird, sollte dadurch auch verringert werden.