### PR TITLE
Info-Dialog XWindow parameter hinzugefügt.

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/dialog/InfoDialog.java
+++ b/src/de/muenchen/allg/itd51/wollmux/dialog/InfoDialog.java
@@ -84,7 +84,12 @@ public class InfoDialog
   {
     try
     {
-      XMessageBox messageBox = createToolkit().createMessageBox(
+      XToolkit2 toolkit = createToolkit();
+
+      if (toolkit == null)
+        return -1;
+
+      XMessageBox messageBox = toolkit.createMessageBox(
           UNO.XWindowPeer(UNO.desktop.getCurrentFrame().getContainerWindow()), type, buttons, title,
           message);
 
@@ -102,7 +107,12 @@ public class InfoDialog
   {
     try
     {
-      XMessageBox messageBox = createToolkit().createMessageBox(
+      XToolkit2 toolkit = createToolkit();
+
+      if (toolkit == null)
+        return -1;
+
+      XMessageBox messageBox = toolkit.createMessageBox(
           UNO.XWindowPeer(window), type, buttons, title,
           message);
 

--- a/src/de/muenchen/allg/itd51/wollmux/dialog/InfoDialog.java
+++ b/src/de/muenchen/allg/itd51/wollmux/dialog/InfoDialog.java
@@ -8,7 +8,9 @@ import com.sun.star.awt.MessageBoxResults;
 import com.sun.star.awt.MessageBoxType;
 import com.sun.star.awt.XMessageBox;
 import com.sun.star.awt.XToolkit2;
+import com.sun.star.awt.XWindow;
 import com.sun.star.lang.XMultiComponentFactory;
+import com.sun.star.uno.Exception;
 import com.sun.star.uno.UnoRuntime;
 
 import de.muenchen.allg.afid.UNO;
@@ -32,6 +34,11 @@ public class InfoDialog
    * @param message
    *          die Nachricht, die im Dialog angezeigt werden soll.
    */
+  public static void showInfoModal(XWindow window, String title, String message)
+  {
+    createDialog(window, title, message, MessageBoxType.INFOBOX, MessageBoxButtons.BUTTONS_OK);
+  }
+
   public static void showInfoModal(String title, String message)
   {
     createDialog(title, message, MessageBoxType.INFOBOX, MessageBoxButtons.BUTTONS_OK);
@@ -77,18 +84,51 @@ public class InfoDialog
   {
     try
     {
-      XMultiComponentFactory xMCF = UNO.defaultContext.getServiceManager();
-      XToolkit2 toolkit = UnoRuntime.queryInterface(XToolkit2.class,
-          xMCF.createInstanceWithContext("com.sun.star.awt.Toolkit", UNO.defaultContext));
-      XMessageBox messageBox = toolkit.createMessageBox(
+      XMessageBox messageBox = createToolkit().createMessageBox(
           UNO.XWindowPeer(UNO.desktop.getCurrentFrame().getContainerWindow()), type, buttons, title,
           message);
+
       return messageBox.execute();
-    } catch (com.sun.star.uno.Exception | NullPointerException e)
+    } catch (NullPointerException e)
     {
       LOGGER.error("Info Dialog {} konnte nicht erstellt werden.", title);
       LOGGER.error("", e);
     }
     return -1;
+  }
+
+  private static short createDialog(XWindow window, String title, String message,
+      MessageBoxType type, int buttons)
+  {
+    try
+    {
+      XMessageBox messageBox = createToolkit().createMessageBox(
+          UNO.XWindowPeer(window), type, buttons, title,
+          message);
+
+      return messageBox.execute();
+    } catch (NullPointerException e)
+    {
+      LOGGER.error("Info Dialog {} konnte nicht erstellt werden.", title);
+      LOGGER.error("", e);
+    }
+    return -1;
+  }
+
+  private static XToolkit2 createToolkit()
+  {
+    XMultiComponentFactory xMCF = UNO.defaultContext.getServiceManager();
+    XToolkit2 toolkit = null;
+
+    try
+    {
+      toolkit = UnoRuntime.queryInterface(XToolkit2.class,
+          xMCF.createInstanceWithContext("com.sun.star.awt.Toolkit", UNO.defaultContext));
+    } catch (Exception e)
+    {
+      LOGGER.error("", e);
+    }
+
+    return toolkit;
   }
 }

--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnInitialize.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnInitialize.java
@@ -1,7 +1,6 @@
 package de.muenchen.allg.itd51.wollmux.event.handlers;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,7 +23,6 @@ import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
 import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
-import de.muenchen.allg.itd51.wollmux.dialog.InfoDialog;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
 
 /**
@@ -59,23 +57,6 @@ public class OnInitialize extends BasicEvent
         WollMuxEventHandler.getInstance().handleShowDialogAbsenderAuswaehlen();
       else
         WollMuxEventHandler.getInstance().handlePALChangedNotify();
-    } else
-    {
-      // Liste der nicht zuordnenbaren Datensätze erstellen und ausgeben:
-      String names = "";
-      List<String> lost = DatasourceJoinerFactory
-          .getLostDatasetDisplayStrings();
-      if (!lost.isEmpty())
-      {
-        for (String l : lost)
-          names += "- " + l + "\n";
-        String message = L.m("Die folgenden Datensätze konnten nicht "
-            + "aus der Datenbank aktualisiert werden:\n\n" + "%1\n"
-            + "Wenn dieses Problem nicht temporärer "
-            + "Natur ist, sollten Sie diese Datensätze aus "
-            + "ihrer Absenderliste löschen und neu hinzufügen!", names);
-        InfoDialog.showInfoModal(L.m("WollMux-Info"), message);
-      }
     }
   }
 

--- a/src/de/muenchen/allg/itd51/wollmux/sidebar/WollMuxSidebarContent.java
+++ b/src/de/muenchen/allg/itd51/wollmux/sidebar/WollMuxSidebarContent.java
@@ -4,6 +4,7 @@ import java.awt.SystemColor;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -59,6 +60,7 @@ import de.muenchen.allg.afid.UNO;
 import de.muenchen.allg.itd51.wollmux.PersoenlicheAbsenderliste;
 import de.muenchen.allg.itd51.wollmux.WollMuxFiles;
 import de.muenchen.allg.itd51.wollmux.XPALChangeEventListener;
+import de.muenchen.allg.itd51.wollmux.core.db.DatasourceJoiner;
 import de.muenchen.allg.itd51.wollmux.core.dialog.UIElementContext;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractActionListener;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractFocusListener;
@@ -70,6 +72,7 @@ import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractWindowListener
 import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
+import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
 import de.muenchen.allg.itd51.wollmux.dialog.InfoDialog;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
 import de.muenchen.allg.itd51.wollmux.sidebar.controls.UIButton;
@@ -199,6 +202,27 @@ public class WollMuxSidebarContent extends ComponentBase implements XToolPanel,
 
     this.parentWindow.addWindowListener(this.windowAdapter);
     layout = new SimpleLayoutManager(this.parentWindow);
+    
+    DatasourceJoiner dj = DatasourceJoinerFactory.getDatasourceJoiner();
+    
+    if (dj.getLOS().size() > 0)
+    {
+      // Liste der nicht zuordnenbaren Datensätze erstellen und ausgeben:
+      String names = "";
+      List<String> lost = DatasourceJoinerFactory
+          .getLostDatasetDisplayStrings();
+      if (!lost.isEmpty())
+      {
+        for (String l : lost)
+          names += "- " + l + "\n";
+        String message = L.m("Die folgenden Datensätze konnten nicht "
+            + "aus der Datenbank aktualisiert werden:\n\n" + "%1\n"
+            + "Wenn dieses Problem nicht temporärer "
+            + "Natur ist, sollten Sie diese Datensätze aus "
+            + "ihrer Absenderliste löschen und neu hinzufügen!", names);
+        InfoDialog.showInfoModal(this.parentWindow, L.m("WollMux-Info"), message);
+      }
+    }
 
     ConfigThingy conf = WollMuxFiles.getWollmuxConf();
 


### PR DESCRIPTION
Minor change.
Bei OnInitialize() ist UNO.desktop.getCurrentFrame().getContainerWindow() noch NULL.
Entsprechenden Info-Dialog-Aufruf wurde in WollMuxSideBarContent verschoben.
UNO.desktop...ist zu diesem Zeitpunkt immer noch NULL, der Info-Dialog kann jedoch durch vorhandes parentWindow der Sidebar angezeigt werden.