### PR TITLE
Info-Dialog XWindow parameter hinzugefügt.

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnInitialize.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnInitialize.java
@@ -1,7 +1,6 @@
 package de.muenchen.allg.itd51.wollmux.event.handlers;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,7 +23,6 @@ import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
 import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
-import de.muenchen.allg.itd51.wollmux.dialog.InfoDialog;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
 
 /**
@@ -59,23 +57,6 @@ public class OnInitialize extends BasicEvent
         WollMuxEventHandler.getInstance().handleShowDialogAbsenderAuswaehlen();
       else
         WollMuxEventHandler.getInstance().handlePALChangedNotify();
-    } else
-    {
-      // Liste der nicht zuordnenbaren Datensätze erstellen und ausgeben:
-      String names = "";
-      List<String> lost = DatasourceJoinerFactory
-          .getLostDatasetDisplayStrings();
-      if (!lost.isEmpty())
-      {
-        for (String l : lost)
-          names += "- " + l + "\n";
-        String message = L.m("Die folgenden Datensätze konnten nicht "
-            + "aus der Datenbank aktualisiert werden:\n\n" + "%1\n"
-            + "Wenn dieses Problem nicht temporärer "
-            + "Natur ist, sollten Sie diese Datensätze aus "
-            + "ihrer Absenderliste löschen und neu hinzufügen!", names);
-        InfoDialog.showInfoModal(L.m("WollMux-Info"), message);
-      }
     }
   }
 

--- a/src/de/muenchen/allg/itd51/wollmux/sidebar/WollMuxSidebarContent.java
+++ b/src/de/muenchen/allg/itd51/wollmux/sidebar/WollMuxSidebarContent.java
@@ -4,6 +4,7 @@ import java.awt.SystemColor;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -59,6 +60,7 @@ import de.muenchen.allg.afid.UNO;
 import de.muenchen.allg.itd51.wollmux.PersoenlicheAbsenderliste;
 import de.muenchen.allg.itd51.wollmux.WollMuxFiles;
 import de.muenchen.allg.itd51.wollmux.XPALChangeEventListener;
+import de.muenchen.allg.itd51.wollmux.core.db.DatasourceJoiner;
 import de.muenchen.allg.itd51.wollmux.core.dialog.UIElementContext;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractActionListener;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractFocusListener;
@@ -70,6 +72,7 @@ import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractWindowListener
 import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
+import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
 import de.muenchen.allg.itd51.wollmux.dialog.InfoDialog;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
 import de.muenchen.allg.itd51.wollmux.sidebar.controls.UIButton;
@@ -199,6 +202,27 @@ public class WollMuxSidebarContent extends ComponentBase implements XToolPanel,
 
     this.parentWindow.addWindowListener(this.windowAdapter);
     layout = new SimpleLayoutManager(this.parentWindow);
+    
+    DatasourceJoiner dj = DatasourceJoinerFactory.getDatasourceJoiner();
+    
+    if (dj.getLOS().size() > 0)
+    {
+      // Liste der nicht zuordnenbaren Datensätze erstellen und ausgeben:
+      String names = "";
+      List<String> lost = DatasourceJoinerFactory
+          .getLostDatasetDisplayStrings();
+      if (!lost.isEmpty())
+      {
+        for (String l : lost)
+          names += "- " + l + "\n";
+        String message = L.m("Die folgenden Datensätze konnten nicht "
+            + "aus der Datenbank aktualisiert werden:\n\n" + "%1\n"
+            + "Wenn dieses Problem nicht temporärer "
+            + "Natur ist, sollten Sie diese Datensätze aus "
+            + "ihrer Absenderliste löschen und neu hinzufügen!", names);
+        InfoDialog.showInfoModal(this.parentWindow, L.m("WollMux-Info"), message);
+      }
+    }
 
     ConfigThingy conf = WollMuxFiles.getWollmuxConf();
 


### PR DESCRIPTION
Minor change.
Bei OnInitialize() ist UNO.desktop.getCurrentFrame().getContainerWindow() noch NULL.
Entsprechender Info-Dialog-Aufruf wurde in WollMuxSideBarContent verschoben.
UNO.desktop...ist zu diesem Zeitpunkt immer noch NULL, der Info-Dialog kann jedoch durch existentes parentWindow der Sidebar angezeigt werden.