### PR TITLE
trac#28853 Controller handling

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/document/TextDocumentController.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/TextDocumentController.java
@@ -667,29 +667,6 @@ public class TextDocumentController implements FormValueChangedListener, Visibil
   }
 
   /**
-   * Diese Methode blockt/unblocked die Contoller, die für das Rendering der
-   * Darstellung in den Dokumenten zuständig sind, jedoch nur, wenn nicht der
-   * debug-modus gesetzt ist.
-   *
-   * @param state
-   */
-  public synchronized void setLockControllers(boolean lock)
-  {
-    try
-    {
-      if (!WollMuxFiles.isDebugMode() && UNO.XModel(model.doc) != null)
-      {
-        if (lock)
-          UNO.XModel(model.doc).lockControllers();
-        else
-          UNO.XModel(model.doc).unlockControllers();
-      }
-    }
-    catch (java.lang.Exception e)
-    {}
-  }
-
-  /**
    * Diese Methode prüft ob die Formularwerte der in fields enthaltenen
    * Formularfelder konsistent aus den in mapIdToValue enthaltenen Werten abgeleitet
    * werden können; Der Wert value beschreibt dabei den Wert der für

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/MainProcessor.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/MainProcessor.java
@@ -12,14 +12,14 @@ import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
 
 /**
  * Der Hauptverarbeitungsschritt, in dem vor allem die Textinhalte gefüllt werden.
- * 
+ *
  * @author christoph.lutz
- * 
+ *
  */
 class MainProcessor extends AbstractExecutor
 {
   /**
-   * 
+   *
    */
   private final DocumentCommandInterpreter documentCommandInterpreter;
 
@@ -36,18 +36,7 @@ class MainProcessor extends AbstractExecutor
    */
   int execute(DocumentCommands commands)
   {
-    try
-    {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(true);
-
-      int errors = executeAll(commands);
-
-      return errors;
-    }
-    finally
-    {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(false);
-    }
+    return executeAll(commands);
   }
 
   /**

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/SurroundingGarbageCollector.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/SurroundingGarbageCollector.java
@@ -22,7 +22,7 @@ import de.muenchen.allg.ooo.TextDocument;
 class SurroundingGarbageCollector extends AbstractExecutor
 {
   /**
-   * 
+   *
    */
   private final DocumentCommandInterpreter documentCommandInterpreter;
 
@@ -98,24 +98,16 @@ class SurroundingGarbageCollector extends AbstractExecutor
 
   /**
    * Löscht die vorher als Müll identifizierten Inhalte. type filter text
-   * 
+   *
    * @author Matthias Benkmann (D-III-ITD 5.1) TESTED
    */
   void removeGarbage()
   {
-    try
+    Iterator<Muellmann> iter = muellmaenner.iterator();
+    while (iter.hasNext())
     {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(true);
-      Iterator<Muellmann> iter = muellmaenner.iterator();
-      while (iter.hasNext())
-      {
-        Muellmann muellmann = iter.next();
-        muellmann.tueDeinePflicht();
-      }
-    }
-    finally
-    {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(false);
+      Muellmann muellmann = iter.next();
+      muellmann.tueDeinePflicht();
     }
   }
 
@@ -161,7 +153,7 @@ class SurroundingGarbageCollector extends AbstractExecutor
    * des übergebenen Dokumentkommandos cmd, wobei über removeAnLastEmptyParagraph
    * gesteuert werden kann, ob ein Absatz am Ende eines Textes gelöscht werden soll
    * (bei true) oder nicht (bei false).
-   * 
+   *
    * @author Matthias Benkmann (D-III-ITD 5.1) TESTED
    */
   private void collectSurroundingGarbageForCommand(DocumentCommand cmd,
@@ -175,29 +167,29 @@ class SurroundingGarbageCollector extends AbstractExecutor
      * Absatzes steht). Ein "T" an dritter Stelle gibt an, dass hinter dem Absatz
      * des Einfügemarkers eine Tabelle folgt. Ein "E" an dritter Stelle gibt an,
      * dass hinter dem Cursor das Dokument aufhört und kein weiterer Absatz kommt.
-     * 
+     *
      * Startmarke: Grundsätzlich gibt es die folgenden Fälle zu unterscheiden.
-     * 
+     *
      * 00: Einfügemarker und Zeilenumbruch DAHINTER löschen
-     * 
+     *
      * 01: nur Einfügemarker löschen
-     * 
+     *
      * 10: nur Einfügemarker löschen
-     * 
+     *
      * 11: nur Einfügemarker löschen
-     * 
+     *
      * 00T: Einfügemarker und Zeilenumbruch DAVOR löschen
-     * 
+     *
      * Die Fälle 01T, 10T und 11T werden nicht unterstützt.
-     * 
+     *
      * Endmarke: Es gibt die folgenden Fälle:
-     * 
+     *
      * 00: Einfügemarker und Zeilenumbruch DAHINTER löschen
-     * 
+     *
      * 00E: Einfügemarker und Zeilenumbruch DAVOR löschen
-     * 
+     *
      * 01, 10, 11: Einfügemarker löschen
-     * 
+     *
      * DO NOT TOUCH THIS CODE ! Dieser Code ist komplex und fehleranfällig.
      * Kleinste Änderungen können dafür sorgen, dass irgendeine der 1000e von
      * Vorlagen plötzlich anders dargestellt wird. Das gewünschte Verhalten dieses

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/TextFieldUpdater.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/TextFieldUpdater.java
@@ -38,17 +38,7 @@ class TextFieldUpdater extends AbstractExecutor
    */
   int execute(DocumentCommands commands)
   {
-    try
-    {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(true);
-
-      return executeAll(commands);
-    }
-    finally
-    {
-      this.documentCommandInterpreter.getDocumentController().setLockControllers(false);
-    }
-
+    return executeAll(commands);
   }
 
   /**


### PR DESCRIPTION
Während WollMux die Commandos bearbeitet, hat er die GUI-Controller
von LibreOffice abgeschalten. Dies sollte die Performanz verbessern. Das
hat aber zu einem Absturz beim Wechseln in die Druckvorschau zur
Ursache. Der Performanzgewinn ist relativ klein und deswegen wird das
an- und abschalten der Controller ganz entfernt.