### PR TITLE
Tabs und Focus

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/document/TextDocumentController.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/TextDocumentController.java
@@ -2404,19 +2404,26 @@ public class TextDocumentController implements FormValueChangedListener, Visibil
     return formModel;
   }
 
-  public FormController createFormController() throws FormModelException
+  public FormController getFormController() throws FormModelException
   {
-    // Abschnitt Fenster/Formular aus wollmuxConf holen:
-    ConfigThingy formFensterConf;
-    try
+    FormController formController = DocumentManager.getDocumentManager()
+        .getFormModel(getModel().doc);
+    if (formController == null)
     {
-      formFensterConf = WollMuxFiles.getWollmuxConf().query("Fenster").query("Formular")
-          .getLastChild();
-    } catch (NodeNotFoundException x)
-    {
-      formFensterConf = new ConfigThingy("");
+      // Abschnitt Fenster/Formular aus wollmuxConf holen:
+      ConfigThingy formFensterConf;
+      try
+      {
+        formFensterConf = WollMuxFiles.getWollmuxConf().query("Fenster").query("Formular")
+            .getLastChild();
+      } catch (NodeNotFoundException x)
+      {
+        formFensterConf = new ConfigThingy("");
+      }
+      formController = new FormController(getFormModel(), formFensterConf, this);
+      DocumentManager.getDocumentManager().setFormModel(getModel().doc, formController);
     }
-    return new FormController(getFormModel(), formFensterConf, this);
+    return formController;
   }
 
   /**
@@ -2503,7 +2510,7 @@ public class TextDocumentController implements FormValueChangedListener, Visibil
   /**
    * Setzt den Wert aller Formularfelder im Dokument, die von fieldId abhängen auf den neuen Wert
    * newValue (bzw. auf das Ergebnis der zu diesem Formularelement hinterlegten Trafo-Funktion).
-   * 
+   *
    * Es ist nicht garantiert, dass sich der Wert tatsächlich geändert hat. Die fieldId kann leer
    * sein (aber nie null).
    */
@@ -2518,7 +2525,7 @@ public class TextDocumentController implements FormValueChangedListener, Visibil
 
   /**
    * Setzt den Sichtbarkeitsstatus der Sichtbarkeitsgruppe mit der ID groupID auf visible.
-   * 
+   *
    * @param groupId
    *          Die ID der Gruppe, die Sichtbar/unsichtbar geschalten werden soll.
    * @param visible

--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
@@ -111,6 +111,7 @@ public class OnNotifyDocumentEventListener extends BasicEvent
 
           FormController formController = DocumentManager.getDocumentManager()
               .getFormModel(xTextDoc);
+          formController.showFormGUI();
 
           setWindowPosSize(formController, documentController, xTextDoc);
 
@@ -121,7 +122,7 @@ public class OnNotifyDocumentEventListener extends BasicEvent
       }
     }
   }
-  
+
   /**
    * Setzt die Position des Fensters auf die übergebenen Koordinaten, wobei die
    * Nachteile der UNO-Methode setWindowPosSize greifen, bei der die Fensterposition
@@ -152,7 +153,7 @@ public class OnNotifyDocumentEventListener extends BasicEvent
         setIsMaximized.invoke(o, false);
       }
     } catch (java.lang.Exception e)
-    {      
+    {
       LOGGER.debug("", e);
     }
 

--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnProcessTextDocument.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnProcessTextDocument.java
@@ -1,7 +1,5 @@
 package de.muenchen.allg.itd51.wollmux.event.handlers;
 
-import java.beans.PropertyChangeEvent;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +11,6 @@ import de.muenchen.allg.itd51.wollmux.core.form.model.FormModelException;
 import de.muenchen.allg.itd51.wollmux.core.parser.ConfigThingy;
 import de.muenchen.allg.itd51.wollmux.core.parser.NodeNotFoundException;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
-import de.muenchen.allg.itd51.wollmux.document.DocumentManager;
 import de.muenchen.allg.itd51.wollmux.document.TextDocumentController;
 import de.muenchen.allg.itd51.wollmux.document.commands.DocumentCommandInterpreter;
 import de.muenchen.allg.itd51.wollmux.event.WollMuxEventHandler;
@@ -106,15 +103,9 @@ public class OnProcessTextDocument extends BasicEvent
         // FormGUI starten
         try
         {
-          FormController formController = documentController.createFormController();
-          DocumentManager.getDocumentManager().setFormModel(documentController.getModel().doc,
-              formController);
-          formController.startFormGUI();
+          FormController formController = documentController.getFormController();
+          formController.createFormGUI();
           formController.formControllerInitCompleted();
-
-          formController.focusGained(formController.getFieldId());
-
-          formController.addPropertyChangeListener((PropertyChangeEvent e) -> formController.focusGained( formController.getFieldId()));
         } catch (FormModelException e)
         {
           throw new WMCommandsFailedException(

--- a/src/de/muenchen/allg/itd51/wollmux/form/control/FormController.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/control/FormController.java
@@ -60,13 +60,10 @@ public class FormController
   private String defaultWindowAttributes;
 
   private PropertyChangeSupport changes = new PropertyChangeSupport( this );
-  private PropertyChangeSupport fieldIdChanges = new PropertyChangeSupport( this );
 
   private Rectangle frameBounds;
   private Rectangle maxWindowBounds;
   private Insets windowInsets;
-
-  private String fieldId;
 
   public Rectangle getFrameBounds()
   {
@@ -98,17 +95,6 @@ public class FormController
   public void removePropertyChangeListener( PropertyChangeListener l )
   {
     changes.removePropertyChangeListener( l );
-  }
-
-  public String getFieldId()
-  {
-    return fieldId;
-  }
-
-  public void setFieldId(String fieldId)
-  {
-    this.fieldId = fieldId;
-    fieldIdChanges.firePropertyChange("name", null, null);
   }
 
 
@@ -284,18 +270,23 @@ public class FormController
    * Baut die GUI zusammen und zeigt diese an. Sobald, die GUI angezeigt wurde wird die Methode
    * {@link #formControllerInitCompleted()} aufgerufen.
    */
-  public void startFormGUI()
+  public void createFormGUI()
   {
     Runnable runner = () -> {
       try
       {
-        gui.create(model, true);
+        gui.create(model);
       } catch (Exception x)
       {
         LOGGER.error("", x);
       }
     };
     gui.createGUI(runner);
+  }
+
+  public void showFormGUI()
+  {
+    gui.show(true);
   }
 
   /**

--- a/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
@@ -174,7 +174,7 @@ public class GUI
     noProcessValueChangedEvents.remove(id);
   }
 
-  public void create(FormModel model, boolean visible)
+  public void create(FormModel model)
   {
     Common.setLookAndFeelOnce();
     initFactories();
@@ -211,7 +211,6 @@ public class GUI
 
     myFrame.pack();
     myFrame.setResizable(true);
-    myFrame.setVisible(visible);
 
     naturalFrameBounds = myFrame.getBounds();
 
@@ -222,8 +221,11 @@ public class GUI
     arrangeWindows();
     model.addFormModelChangedListener(this, true);
     model.addVisibilityChangedListener(this, true);
+  }
 
-    processUIElementEvents = true;
+  public void show(boolean visible)
+  {
+    myFrame.setVisible(visible);
   }
 
   private Component createTab(Tab tab, Color plausiMarkerColor, boolean focus)
@@ -835,7 +837,7 @@ public class GUI
         if ("lost".equals(args[0]))
           controller.focusLost(source.getId());
         else
-          controller.setFieldId(source.getId());
+          controller.focusGained(source.getId());
       }
     } catch (Exception x)
     {


### PR DESCRIPTION
* Trac#29829: Wenn ein Formularfeld den Fokus erhält, so wird automatisch auch zu dem Controll im Dokument gesprungen
* Trac#29855: Tabs ohne sichtbare Felder werden deaktiviert

**Benötigt https://github.com/WollMux/wollmux-core/pull/45**