### PR TITLE
trac#30187 fix loading of Styles 

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/DocumentLoader.java
@@ -93,8 +93,7 @@ public class DocumentLoader
   {
     try
     {
-      ByteBuffer buf = cache.get(path);
-      XInputStream in = new ByteBufferInputStream(buf);
+      XInputStream in = getDocumentStream(path);
       UNO.XDocumentInsertable(target).insertDocumentFromURL(path,
         new PropertyValue[] {
           new PropertyValue("InputStream", -1, in, PropertyState.DIRECT_VALUE),
@@ -121,8 +120,7 @@ public class DocumentLoader
   {
     try
     {
-      ByteBuffer buf = cache.get(path);
-      XInputStream in = new ByteBufferInputStream(buf);
+      XInputStream in = getDocumentStream(path);
       return UNO.loadComponentFromURL(path, asTemplate, allowMacros,
           new PropertyValue("InputStream", -1, in, PropertyState.DIRECT_VALUE), new PropertyValue(
               "FilterName", -1, "StarOffice XML (Writer)", PropertyState.DIRECT_VALUE));
@@ -139,16 +137,9 @@ public class DocumentLoader
     return cache.getIfPresent(path) != null;
   }
 
-  public XInputStream getDocumentStream(String path)
+  public XInputStream getDocumentStream(String path) throws ExecutionException
   {
-    try
-    {
-      ByteBuffer buf = cache.get(path);
-      return new ByteBufferInputStream(buf);
-    } catch (ExecutionException e)
-    {
-      LOGGER.error("", e);
-    }
-    return null;
+    ByteBuffer buf = cache.get(path);
+    return new ByteBufferInputStream(buf);
   }
 }

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -463,7 +464,7 @@ class DocumentExpander extends AbstractExecutor
       props.setPropertyValue("InputStream", stream);
       loader.loadStylesFromURL("private:stream", props.getProps());
     }
-    catch (NullPointerException e)
+    catch (NullPointerException | ExecutionException e)
     {
       LOGGER.error("", e);
     }

--- a/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
+++ b/src/de/muenchen/allg/itd51/wollmux/document/commands/DocumentExpander.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +15,6 @@ import com.sun.star.beans.XPropertySet;
 import com.sun.star.container.XEnumeration;
 import com.sun.star.container.XEnumerationAccess;
 import com.sun.star.io.IOException;
-import com.sun.star.io.XInputStream;
 import com.sun.star.lang.IllegalArgumentException;
 import com.sun.star.style.XStyleFamiliesSupplier;
 import com.sun.star.style.XStyleLoader;
@@ -460,11 +458,9 @@ class DocumentExpander extends AbstractExecutor
         Boolean.valueOf(styles.contains("numberingstyles")));
       XStyleFamiliesSupplier sfs = UNO.XStyleFamiliesSupplier(this.documentCommandInterpreter.getModel().doc);
       XStyleLoader loader = UNO.XStyleLoader(sfs.getStyleFamilies());
-      XInputStream stream = DocumentLoader.getInstance().getDocumentStream(urlStr);
-      props.setPropertyValue("InputStream", stream);
-      loader.loadStylesFromURL("private:stream", props.getProps());
+      loader.loadStylesFromURL(urlStr, props.getProps());
     }
-    catch (NullPointerException | ExecutionException e)
+    catch (NullPointerException e)
     {
       LOGGER.error("", e);
     }


### PR DESCRIPTION
with commit f4ddff7 caching was enabled,
but this breaks the loading of styles as the method
XStyleLoader.loadStylesFromURL(url, props) does not support urls with
"private:stream" and therefore does nothing so the styles were not loaded.

As a temporary solution, until libreoffice supports loading of styles via
stream, the caching is disabled for styles.