### PR TITLE
trac#28594 ConcurrentModificationException

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
@@ -74,20 +74,9 @@ public class OnNotifyDocumentEventListener extends BasicEvent
       {
         final XEventListener docListener = i.next();
         if (this.listener == null || this.listener == docListener)
-          new Thread()
-          {
-            @Override
-            public void run()
-            {
-              try
-              {
-                docListener.notifyEvent(eventObject);
-              } catch (java.lang.Exception x)
-              {
-                LOGGER.debug("", x);
-              }
-            }
-          }.start();
+        {
+          docListener.notifyEvent(eventObject);
+        }
       } catch (java.lang.Exception e)
       {
         i.remove();


### PR DESCRIPTION
There was a listener called in a new Thread, which deregistered itself.
Because of the new Thread the Event for deregistering was executed in
parallel with the thread calling all listeners in a loop.