### PR TITLE
trac#31069 tab inactive although there are visible elements

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
@@ -928,6 +928,11 @@ public class GUI
         {
           myTabbedPane.setEnabledAt(tabIndex, false);
         }
+        if (tabVisibleCount[tabIndex] < 0)
+        {
+          LOGGER.warn("Anzahl der sichtbaren Elemente auf Tab {} ist {}", tabIndex,
+              tabVisibleCount[tabIndex]);
+        }
       }
     }
   }
@@ -957,14 +962,15 @@ public class GUI
       {
         for (UIElement element : visibilityGroups.get(id))
         {
+          boolean changed = false;
           if (element.getComponent() instanceof JButton)
           {
-            element.setEnabled(visible);
+            changed = element.setEnabled(visible);
           } else
           {
-            element.setVisible(visible);
+            changed = element.setVisible(visible);
           }
-          if (!element.isStatic())
+          if (!element.isStatic() && changed)
           {
             setTabVisibleCount(element.getTab(), visible);
           }


### PR DESCRIPTION
If elements are in several visiblity groups and they all change their state,
the number of visible elements per tab is decreased several times per element.
Now we only decrease if the state of an element has really changed and not always.

Requires https://github.com/WollMux/wollmux-core/pull/53