### PR TITLE
Private/jmux/office shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<libreoffice.version>6.4.0-SNAPSHOT</libreoffice.version>
 		<wollmux.oxt.id>de.muenchen.allg.d101.wollmux</wollmux.oxt.id>
 		<wollmux.oxt.name>WollMux</wollmux.oxt.name>
+		<maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
 	</properties>
 
 	<scm>
@@ -93,7 +94,6 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.1.1</version>
 				<configuration>
-					<failOnWarnings>true</failOnWarnings>
 					<quiet>true</quiet>
 				</configuration>
 				<executions>

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/TextDocumentModel.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/TextDocumentModel.java
@@ -1440,6 +1440,11 @@ public class TextDocumentModel
         {
           UNO.XCloseable(doc).close(true);
         }
+
+        XFrame[] frames = UNO.XFramesSupplier(UNO.desktop).getFrames()
+            .queryFrames(FrameSearchFlag.ALL);
+        if (frames.length <= 1)
+          UNO.desktop.terminate();
       }
       catch (CloseVetoException e)
       {


### PR DESCRIPTION
Two small patches to shut down LO when the last document is closed by WollMux. The POM change is actually not needed, so feel free to drop that.