### PR TITLE
remove property FOLLOW_STYLE from char styles

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/slv/ContentBasedDirectiveModel.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/slv/ContentBasedDirectiveModel.java
@@ -302,7 +302,7 @@ public class ContentBasedDirectiveModel
    */
   private void createUsedStyles()
   {
-    // Absatzformate:
+    // paragraph styles
     XStyle style = documentModel.getParagraphStyle(PARA_STYLE_NAME_DEFAULT);
     if (style == null)
     {
@@ -362,13 +362,11 @@ public class ContentBasedDirectiveModel
       Utils.setProperty(style, PropertyName.CHAR_UNDERLINE, Integer.valueOf(1));
     }
 
-    // Zeichenformate:
-
+    // character styles
     style = documentModel.getCharacterStyle(CHAR_STYLE_NAME_DEFAULT);
     if (style == null)
     {
       style = documentModel.createCharacterStyle(CHAR_STYLE_NAME_DEFAULT, null);
-      Utils.setProperty(style, PropertyName.FOLLOW_STYLE, CHAR_STYLE_NAME_DEFAULT);
       Utils.setProperty(style, PropertyName.CHAR_HEIGHT, Integer.valueOf(11));
       Utils.setProperty(style, PropertyName.CHAR_FONT_NAME, "Arial");
       Utils.setProperty(style, PropertyName.CHAR_UNDERLINE, Integer.valueOf(0));
@@ -378,7 +376,6 @@ public class ContentBasedDirectiveModel
     if (style == null)
     {
       style = documentModel.createCharacterStyle(CHAR_STYLE_NAME_NUMBER, CHAR_STYLE_NAME_DEFAULT);
-      Utils.setProperty(style, PropertyName.FOLLOW_STYLE, CHAR_STYLE_NAME_DEFAULT);
       Utils.setProperty(style, PropertyName.CHAR_WEIGHT, Float.valueOf(FontWeight.BOLD));
     }
   }


### PR DESCRIPTION
FOLLOW_STYLE is usually only available on paragraph styles only.
https://api.libreoffice.org/docs/idl/ref/servicecom_1_1sun_1_1star_1_1style_1_1Style.html#a1f49e6edb118da6ff6a1db56fd884b57