### PR TITLE
trac#31617 Don't delete selection in pal list, if another input field…

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/dialog/PersoenlicheAbsenderlisteVerwalten.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/dialog/PersoenlicheAbsenderlisteVerwalten.java
@@ -89,6 +89,7 @@ import de.muenchen.allg.itd51.wollmux.core.db.DatasourceJoiner;
 import de.muenchen.allg.itd51.wollmux.core.db.LocalOverrideStorageStandardImpl.LOSDJDataset;
 import de.muenchen.allg.itd51.wollmux.core.db.QueryResults;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractActionListener;
+import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractFocusListener;
 import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractWindowListener;
 import de.muenchen.allg.itd51.wollmux.core.util.L;
 import de.muenchen.allg.itd51.wollmux.db.DatasourceJoinerFactory;
@@ -142,6 +143,8 @@ public class PersoenlicheAbsenderlisteVerwalten
   private int count = 0;
 
   private short itemToHighlightPos = 0;
+
+  private boolean palListeHasFocus = false;
 
   /**
    * Erzeugt einen neuen Dialog.
@@ -236,6 +239,21 @@ public class PersoenlicheAbsenderlisteVerwalten
 
     addPalEntriesToListBox();
 
+    UNO.XWindow(palListe).addFocusListener(new AbstractFocusListener()
+    {
+      @Override
+      public void focusGained(com.sun.star.awt.FocusEvent event)
+      {
+        palListeHasFocus = true;
+      }
+
+      @Override
+      public void focusLost(com.sun.star.awt.FocusEvent event)
+      {
+        palListeHasFocus = false;
+      }
+    });
+
     dialog = UnoRuntime.queryInterface(XDialog.class, window);
     dialog.execute();
   }
@@ -312,7 +330,7 @@ public class PersoenlicheAbsenderlisteVerwalten
           setLdapSearchResults(result);
           showInfoDialog(result);
         });
-      } else if (arg0.KeyCode == Key.DELETE)
+      } else if (arg0.KeyCode == Key.DELETE && palListeHasFocus)
       {
         // Einträge aus PAL-Listbox entfernen
         short[] selectedItems = palListe.getSelectedItemsPos();


### PR DESCRIPTION
… is deleted

Added focus listener to the pal list, so a deletion command will only
be executed, if the pal list has the focus.