### PR TITLE
trac31474 Avoid call of updateTravelUI in constructor

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/printsettings/FormatWizardPage.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/printsettings/FormatWizardPage.java
@@ -39,6 +39,8 @@ public class FormatWizardPage extends AbstractXWizardPage
   private final MailmergeWizardController controller;
   private final PrintSettings settings;
 
+  private boolean inConstructor;
+
   private final AbstractItemListener formatListener = new AbstractItemListener()
   {
 
@@ -67,6 +69,7 @@ public class FormatWizardPage extends AbstractXWizardPage
       PrintSettings settings) throws Exception
   {
     super(pageId, parentWindow, "vnd.sun.star.script:WollMux.seriendruck_format?location=application");
+    inConstructor = true;
     this.controller = controller;
     this.settings = settings;
     XControlContainer container = UNO.XControlContainer(window);
@@ -83,7 +86,9 @@ public class FormatWizardPage extends AbstractXWizardPage
       @Override
       public void textChanged(TextEvent arg0)
       {
-        controller.updateTravelUI();
+        // avoid cascade of calls between LO and WollMux
+        if(!inConstructor)
+          controller.updateTravelUI();
       }
     });
     mailmerge = UNO.XComboBox(container.getControl("mailmerge"));
@@ -121,6 +126,7 @@ public class FormatWizardPage extends AbstractXWizardPage
         name.setText(name.getText() + append);
       }
     });
+    inConstructor = false;
   }
 
   private FORMAT getSelectedFormat()


### PR DESCRIPTION
This solves only one part of the problems described in #31474.
The other part, display of "2, ...", and "disable continue button in mailmerge wizard
if initially path has only one element" is to be solved in libreoffice.