### PR TITLE
trac#33675 fix selecting table with same name as file

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/dialog/mailmerge/MailMergeDatasource.java
+++ b/src/de/muenchen/allg/itd51/wollmux/dialog/mailmerge/MailMergeDatasource.java
@@ -983,7 +983,7 @@ public class MailMergeDatasource
     {
       for (String tableName : model.getTableNames())
       {
-        if (name.contains(model.getDatasourceName()) && name.contains(tableName))
+        if (name.startsWith(model.getDatasourceName()) && name.endsWith(tableName))
         {
           if (model instanceof DBModel)
           {


### PR DESCRIPTION
If a file name contains the table name this table was selected. No the
start of the internal name has to match the file name and the end of the
internal name has to match the table name.