### PR TITLE
trac#33675 fix selecting table with same name as file

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/ConnectionModel.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/ConnectionModel.java
@@ -129,7 +129,7 @@ public class ConnectionModel
     {
       for (String tableName : ds.getTableNames())
       {
-        if (name.contains(ds.getName()) && name.contains(tableName))
+        if (name.startsWith(ds.getName()) && name.endsWith(tableName))
         {
           LOGGER.info("Datenquelle {} ist ausgewählt.", ds.getName());
           ds.activateTable(tableName);


### PR DESCRIPTION
If a file name contains the table name this table was selected. No the
start of the internal name has to match the file name and the end of the
internal name has to match the table name.