### PR TITLE
trac#33765 Close FormGUI when document is closed

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
@@ -128,7 +128,6 @@ public class GUI
     public void windowClosing(WindowEvent e)
     {
       controller.close();
-      dispose();
     }
 
     @Override


### PR DESCRIPTION
Don't close when "X" is pressed and aborted.