### PR TITLE
handle "null"-sender correctly

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/sender/SenderService.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/sender/SenderService.java
@@ -561,6 +561,10 @@ public class SenderService implements XPALProvider
     } else
     {
       data = newSenderList;
+      if (!newSenderList.isEmpty())
+      {
+        select(newSenderList.get(0));
+      }
     }
     notifyListener();
   }
@@ -610,19 +614,20 @@ public class SenderService implements XPALProvider
    */
   public void select(Sender sender) throws SenderException
   {
-    if (data.contains(sender))
-    {
-      if (this.selectedSender != null)
-      {
-        this.selectedSender.setSelected(false);
-      }
-      this.selectedSender = sender;
-      this.selectedSender.setSelected(true);
-      notifyListener();
-    } else
+    if (sender != null && !data.contains(sender))
     {
       throw new SenderException("Unbekannter Sender wurde ausgewählt.");
     }
+    if (this.selectedSender != null)
+    {
+      this.selectedSender.setSelected(false);
+    }
+    this.selectedSender = sender;
+    if (this.selectedSender != null)
+    {
+      this.selectedSender.setSelected(true);
+    }
+    notifyListener();
   }
 
   /**

--- a/core/src/test/java/de/muenchen/allg/itd51/wollmux/sender/SenderServiceTest.java
+++ b/core/src/test/java/de/muenchen/allg/itd51/wollmux/sender/SenderServiceTest.java
@@ -25,6 +25,7 @@ package de.muenchen.allg.itd51.wollmux.sender;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -133,6 +134,8 @@ public class SenderServiceTest
     assertEquals(service.selectedSender, sender);
     Sender s = new Sender(new MockDataset());
     assertThrows(SenderException.class, () -> service.select(s));
+    service.select(null);
+    assertNull(service.selectedSender);
   }
 
   @Test


### PR DESCRIPTION
if no cache file is present, the select sender is null until
getDefaultSender has been called.