### PR TITLE
controller argument not always given (Trac 33805)

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/form/sidebar/FormFactory.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/form/sidebar/FormFactory.java
@@ -68,9 +68,9 @@ public class FormFactory extends AbstractSidebarFactory
       if (arguments[i].Name.equals("ParentWindow"))
       {
         parentWindow = UNO.XWindow(arguments[i].Value);
-      } else if (arguments[i].Name.equals("Controller"))
+      } else if (arguments[i].Name.equals("Frame"))
       {
-        model = UNO.XController(arguments[i].Value).getModel();
+        model = UNO.XFrame(arguments[i].Value).getController().getModel();
       }
     }
 


### PR DESCRIPTION
If then sidebar is activated after the document has been displayed, the
controller argument is not given. So we have to use the frame in this
case.