### PR TITLE
trac#33815 handle empty ID value

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/ui/UIElementConfig.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/ui/UIElementConfig.java
@@ -185,6 +185,10 @@ public class UIElementConfig
   {
     type = UIElementType.getType(controlConf.getString("TYPE", ""));
     id = controlConf.getString("ID", RandomStringUtils.randomAlphanumeric(10));
+    if (id.isEmpty())
+    {
+      id = RandomStringUtils.randomAlphanumeric(10);
+    }
     label = controlConf.getString("LABEL", "");
     tip = controlConf.getString("TIP", "");
     String hotkeyString = controlConf.getString("HOTKEY", "");

--- a/core/src/test/java/de/muenchen/allg/itd51/wollmux/ui/TestUIElementConfig.java
+++ b/core/src/test/java/de/muenchen/allg/itd51/wollmux/ui/TestUIElementConfig.java
@@ -73,4 +73,20 @@ public class TestUIElementConfig
     assertFalse(control.isSidebar());
   }
 
+  @Test
+  public void testEmptyId() throws Exception
+  {
+    ConfigThingy conf = new ConfigThingy("", "TYPE \"LABEL\" ID \"\"");
+    UIElementConfig control = new UIElementConfig(conf);
+    assertFalse(control.getId().isEmpty());
+  }
+
+  @Test
+  public void testMissingId() throws Exception
+  {
+    ConfigThingy conf = new ConfigThingy("", "TYPE \"LABEL\"");
+    UIElementConfig control = new UIElementConfig(conf);
+    assertFalse(control.getId().isEmpty());
+  }
+
 }


### PR DESCRIPTION
If the form config defined "" as an ID it is discarded and replaced by
a random number. Otherwise we cant distinguish between the controls.