### PR TITLE
handle NumberFormatException in SLV Dialog

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/slv/dialog/ContentBasedDirectiveDialog.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/slv/dialog/ContentBasedDirectiveDialog.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.star.awt.ActionEvent;
+import com.sun.star.awt.Selection;
 import com.sun.star.awt.SpinEvent;
 import com.sun.star.awt.TextEvent;
 import com.sun.star.awt.XButton;
@@ -334,6 +335,10 @@ public class ContentBasedDirectiveDialog
         updateCount(count);
       } catch (NumberFormatException e)
       {
+        UNO.XTextComponent(event.Source).setText("0");
+        Selection selection = UNO.XTextComponent(event.Source).getSelection();
+        selection.Max = 1;
+        UNO.XTextComponent(event.Source).setSelection(selection);
         LOGGER.error("Keine Zahl", e);
       }
     }


### PR DESCRIPTION
empty strings and strings which don't represent are number are replaced
by "0". The cursor selects the number.