### PR TITLE
trac#33889 remove print block not working

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/slv/events/OnMarkBlock.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/slv/events/OnMarkBlock.java
@@ -164,7 +164,7 @@ public class OnMarkBlock extends WollMuxEvent
   private void deleteOrUpdateWithWarning(XTextCursor range, String highlightColor, String markChange,
       String bookmarkName, List<Bookmark> bookmarks)
   {
-    boolean allMatch = bookmarks.stream().allMatch(bookmark -> bookmark.getName().equalsIgnoreCase(bookmarkName));
+    boolean allMatch = bookmarks.stream().allMatch(bookmark -> bookmark.getName().startsWith(bookmarkName));
     if (allMatch)
     {
       bookmarks.forEach(this::deleteBookmark);
@@ -202,7 +202,7 @@ public class OnMarkBlock extends WollMuxEvent
   private void deleteOrUpdate(XTextCursor range, String highlightColor, String markChange, String bookmarkName,
       List<Bookmark> bookmarks)
   {
-    boolean allMatch = bookmarks.stream().allMatch(bookmark -> bookmark.getName().equalsIgnoreCase(bookmarkName));
+    boolean allMatch = bookmarks.stream().allMatch(bookmark -> bookmark.getName().startsWith(bookmarkName));
     bookmarks.forEach(this::deleteBookmark);
     if (allMatch)
     {


### PR DESCRIPTION
If there are several print blocks of the same type (eg copy only), they
can't be deleted by pressing the button again. The problem is the
bookmarks have a number at the end so those not equal the command. So we
now check if the bookmark name starts with the command and if it those
we delete it.