### PR TITLE
Log as warning

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/print/ToOdtFile.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/print/ToOdtFile.java
@@ -64,7 +64,7 @@ public class ToOdtFile extends PrintFunction
       InfoDialog.showInfoModal(L.m("WollMux-Seriendruck"), L.m(e.getMessage()));
     } catch (Exception ex)
     {
-      LOGGER.error("Fehler beim Aufräumen der temporären Dokumente", ex);
+      LOGGER.warn("Fehler beim Aufräumen der temporären Dokumente", ex);
     }
   }
 }

--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/print/ToPrinter.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/mailmerge/print/ToPrinter.java
@@ -63,7 +63,7 @@ public class ToPrinter extends PrintFunction
       InfoDialog.showInfoModal(L.m("WollMux-Seriendruck"), L.m(e.getMessage()));
     } catch (Exception ex)
     {
-      LOGGER.error("Fehler beim Aufräumen der temporären Dokumente", ex);
+      LOGGER.warn("Fehler beim Aufräumen der temporären Dokumente", ex);
     }
   }
 


### PR DESCRIPTION
Sometimes temporary files can't be deleted. It isn't good but not an
error so log it as warning.