### PR TITLE
trac 32113: Bei Standardbutton sind zusätzliche Optionen, beispielsweise

### DIFF
--- a/core/src/main/java/de/muenchen/allg/itd51/wollmux/former/control/OneFormControlLineView.java
+++ b/core/src/main/java/de/muenchen/allg/itd51/wollmux/former/control/OneFormControlLineView.java
@@ -192,7 +192,21 @@ public class OneFormControlLineView extends LineView
     myPanel.add(makeTypeView());
     myPanel.add(makeComboBoxAdditionalView());
     myPanel.add(makeTextAreaAdditionalView());
-    myPanel.add(makeButtonAdditionalView());
+    
+    // additionalview nur bauen wenn kein standard button,
+    // makeButtonAdditionalView baut controls für openTemplate und openExt
+    if (!model.getAction().equals("abort")
+        && !model.getAction().equals("prevTab")
+        && !model.getAction().equals("nextTab")
+        && !model.getAction().equals("funcDialog")
+        && !model.getAction().equals("form2PDF")
+        && !model.getAction().equals("save")
+        && !model.getAction().equals("saveAs")
+        && !model.getAction().equals("printForm")
+        && !model.getAction().equals("closeAndOpenExt")
+        && !model.getAction().equals("saveTempAndOpenExt")
+        && !model.getAction().equals("form2EMail"))
+          myPanel.add(makeButtonAdditionalView());
 
     myPanel.add(makeReadOnlyView());
     normalFont = labelTextfield.getFont();
@@ -244,8 +258,9 @@ public class OneFormControlLineView extends LineView
     readOnlyfield.setVisible(!model.isTab() && viewVisibilityDescriptor != null
         && viewVisibilityDescriptor.isFormControlLineViewReadonly());
 
-    buttonAdditionalView.setVisible(model.isButton() && (viewVisibilityDescriptor == null
-        || viewVisibilityDescriptor.isFormControlLineViewAdditional()));
+    if(buttonAdditionalView != null)
+        buttonAdditionalView.setVisible(model.isButton() && (viewVisibilityDescriptor == null
+            || viewVisibilityDescriptor.isFormControlLineViewAdditional()));
 
     /*
      * Wenn alle abgeschaltet sind, aktiviere zumindest das ID-Feld


### PR DESCRIPTION
Zuweisung der auszuführenden Aktion, nicht nötig und werden daher
ausgeblendet.