### PR TITLE
trac34315

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/WollMuxFiles.java
+++ b/src/de/muenchen/allg/itd51/wollmux/WollMuxFiles.java
@@ -389,25 +389,25 @@ public class WollMuxFiles
         char[] arrWollmuxConfPath = new char[WinDef.MAX_PATH];
         shell.SHGetFolderPath(null, ShlObj.CSIDL_APPDATA, null,
           ShlObj.SHGFP_TYPE_CURRENT, arrWollmuxConfPath);
-        searchPaths.add(Native.toString(arrWollmuxConfPath)
+        searchPaths.add(String.valueOf(arrWollmuxConfPath).trim()
           + "/.wollmux/wollmux.conf");
 
         arrWollmuxConfPath = new char[WinDef.MAX_PATH];
         shell.SHGetFolderPath(null, ShlObj.CSIDL_COMMON_APPDATA, null,
           ShlObj.SHGFP_TYPE_CURRENT, arrWollmuxConfPath);
-        searchPaths.add(Native.toString(arrWollmuxConfPath)
+        searchPaths.add(String.valueOf(arrWollmuxConfPath).trim()
           + "/.wollmux/wollmux.conf");
 
         arrWollmuxConfPath = new char[WinDef.MAX_PATH];
         shell.SHGetFolderPath(null, ShlObj.CSIDL_PROGRAM_FILESX86, null,
           ShlObj.SHGFP_TYPE_CURRENT, arrWollmuxConfPath);
-        searchPaths.add(Native.toString(arrWollmuxConfPath)
+        searchPaths.add(String.valueOf(arrWollmuxConfPath).trim()
           + "/.wollmux/wollmux.conf");
 
         arrWollmuxConfPath = new char[WinDef.MAX_PATH];
         shell.SHGetFolderPath(null, ShlObj.CSIDL_PROGRAM_FILES, null,
           ShlObj.SHGFP_TYPE_CURRENT, arrWollmuxConfPath);
-        searchPaths.add(Native.toString(arrWollmuxConfPath)
+        searchPaths.add(String.valueOf(arrWollmuxConfPath).trim()
           + "/.wollmux/wollmux.conf");
 
       }


### PR DESCRIPTION
Der Aufruf von SHGetFolderPath liefert einen string zurück, der am Ende mit 0-bytes gefüllt ist und daher ein falsches Ergebnis für den Wollmux Pfad liefert. Mit der trim Funtion korrigiert.